### PR TITLE
Update filename to `.tiignore` (no dash in there)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # ti-ignore-plugin
 
-Add .ti-ignore file support to the Titanium CLI build process. Place .ti-ignore
+Add `.tiignore` file support to the Titanium CLI build process. Place `.tiignore`
 files in your project following the [.gitignore](http://git-scm.com/docs/gitignore) syntax. The matching files will not be copied over into the app
 during `ti build`.
+
+You can use one of the following filenames:
+- `.titaniumignore`,
+- `.tiignore`,
+- `.ti-ignore`.
 
 ## How to install
 

--- a/hooks/plugin.js
+++ b/hooks/plugin.js
@@ -21,7 +21,11 @@ exports.init = function (logger, config, cli, appc) {
 	var ignore = require('ignore'),
 		fs = require('fs');
 	var ti_ignore_passing = ignore().addIgnoreFile(
-			ignore.select(['.ti-ignore'])
+			ignore.select([
+				'.titaniumignore',
+				'.tiignore',
+				'.ti-ignore'
+			])
 		).createFilter();
 
 	cli.on("build.pre.compile", function (build, finished) {
@@ -36,7 +40,7 @@ exports.init = function (logger, config, cli, appc) {
 
 			process.nextTick(function() {
 				if (!ti_ignore_passing(source_file)) {
-					logger.info('Ignoring ' + relative_source_file.cyan + ' due to .ti-ignore');
+					logger.info('Ignoring ' + relative_source_file.cyan + ' due to .tiignore');
 					build.fn = null;
 					finished(null, build);
 				} else {


### PR DESCRIPTION
We still support for `.ti-ignore`.

I thought that the double `ii` in the filename could cause trouble, therefore I extended the list of supported filenames to:
- `.titaniumignore`,
- `.tiignore`,
- `.ti-ignore`.
